### PR TITLE
alignment of docs with the CLI help

### DIFF
--- a/bin/help.js
+++ b/bin/help.js
@@ -15,6 +15,10 @@ b('  ' + log.colors.green('rulo') + ' index.js:bundle.js [opts] -- [rollup opts]
 'Options:\n' +
 '  --help, -h          ' + i('Show help message') + '\n' +
 '  --version, -V       ' + i('Show version') + '\n' +
+'  --input, -i         ' + i('overide the entry file to bundle') + '\n' +    
+'  --entry             ' + i('same as --input') + '\n' +
+'  --output, -o        ' + i('overide the default output') + '\n' +    
+'  --dest              ' + i('same as --output') + '\n' +
 '  --port, -p          ' + i('The port to run, default 8080') + '\n' +
 '  --host, -H          ' + i('The host, default local IP and localhost') + '\n' +
 '  --basedir, -d       ' + i('A path for base static content') + '\n' +

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -22,7 +22,7 @@ sudo npm link rulo
 #### `--help` / `-h`
 * Show help message
 
-#### `--version` / `-v`
+#### `--version` / `-V`
 * Show version number for `rulo`, `rollup`, and `another-rollup-watch`
 
 #### `--entry` / `--input` / `-i`


### PR DESCRIPTION
Somehow `>rulo index.js:bundle.js` as shown in the CLI help never works but `>rulo -i entry.js` as shown in the repo docs does work.

Summary of changes
* fixed docs to show `-V` for version instead of `-v`
* added `--input, -i, --entry` and `--output, -o, --dest` to the cli help

There is further alignment required but for that I would need some feedback on the source of truth and the intended future directions.

